### PR TITLE
Add project name in IndexAssignment; Correct index percentage in undet

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,10 @@
 # TACA Version Log
 
+## 20240927.1
+
+Add project name in IndexAssignment;
+Correct index percentage in undet
+
 ## 20240924.1
 
 Aggregate aviti demultiplexing results

--- a/taca/analysis/analysis_element.py
+++ b/taca/analysis/analysis_element.py
@@ -70,7 +70,7 @@ def run_preprocessing(given_run):
             if run.status_changed:
                 run.update_statusdb()
             return
-          
+
         elif demultiplexing_status != "finished":
             logger.warning(
                 f"Unknown demultiplexing status {demultiplexing_status} of run {run}. Please investigate"
@@ -81,7 +81,7 @@ def run_preprocessing(given_run):
         transfer_status = run.get_transfer_status()
         if transfer_status == "not started":
             demux_results_dirs = glob.glob(
-                os.path.join(run.run_dir, "Delmultiplexing_*")
+                os.path.join(run.run_dir, "Demultiplexing_*")
             )
             run.aggregate_demux_results(demux_results_dirs)
             run.sync_metadata()
@@ -107,7 +107,7 @@ def run_preprocessing(given_run):
                     run.update_statusdb()
                 run.archive()
                 run.status = "archived"
-                
+
                 if run.status_changed:
                     run.update_statusdb()
             else:

--- a/taca/element/Element_Runs.py
+++ b/taca/element/Element_Runs.py
@@ -580,7 +580,7 @@ class Run:
                     sample_tuple = (sample_name, sub_demux_count)
                     if sample_tuple not in unique_sample_demux:
                         project_dest = os.path.join(self.run_dir, self.demux_dir, project)
-                        sample_dest = os.path.join(self.run_dir, self.demux_dir, project, sample_name)
+                        sample_dest = os.path.join(self.run_dir, self.demux_dir, project, f"Sample_{sample_name}")
                         if not os.path.exists(project_dest):
                             os.makedirs(project_dest)
                         if not os.path.exists(sample_dest):

--- a/taca/element/Element_Runs.py
+++ b/taca/element/Element_Runs.py
@@ -669,7 +669,7 @@ class Run:
                         sample['QualityScoreMean'] = project_runstats_sample[0]['QualityScoreMean']
                         aggregated_assigned_indexes.append(sample)
             else:
-                logger.warning(f"No IndexAssignment.csv file found for sub-demultiplexing {sub_demux}.")
+                logger.warning(f"No {os.path.basename(assigned_csv)} file found for sub-demultiplexing {sub_demux}.")
         # Remove redundant rows for PhiX
         aggregated_assigned_indexes_filtered = []
         unique_phiX_combination = set()
@@ -717,7 +717,7 @@ class Run:
                     reader = csv.DictReader(max_unassigned_file)
                     max_unassigned_indexes = [row for row in reader]
             else:
-                logger.warning(f"No UnassignedSequences.csv file found for sub-demultiplexing {sub_demux_with_max_index_lens}.")
+                logger.warning(f"No {os.path.basename(max_unassigned_csv)} file found for sub-demultiplexing {sub_demux_with_max_index_lens}.")
                 break
             # Filter by lane
             max_unassigned_indexes = [idx for idx in max_unassigned_indexes if idx["Lane"] == lane]
@@ -732,7 +732,7 @@ class Run:
                             reader = csv.DictReader(unassigned_file)
                             unassigned_indexes = [row for row in reader]
                     else:
-                        logger.warning(f"No UnassignedSequences.csv file found for sub-demultiplexing {sub_demux}.")
+                        logger.warning(f"No {os.path.basename(unassigned_csv)} file found for sub-demultiplexing {sub_demux}.")
                         continue
                     # Filter by lane
                     unassigned_indexes = [unassigned_index for unassigned_index in unassigned_indexes if unassigned_index["Lane"] == lane]
@@ -762,7 +762,7 @@ class Run:
                 if pfcount_lane.get(unassigned_index["Lane"]):
                     unassigned_index["% Polonies"] = float(unassigned_index["Count"])/pfcount_lane[unassigned_index["Lane"]]*100
         else:
-            logger.warning(f"No AvitiRunStats.json file found for the run.")
+            logger.warning(f"No {os.path.basename(self.run_stats_file)} file found for the run.")
 
         # Write to a new UnassignedSequences.csv file under demux_dir
         aggregated_unassigned_csv = os.path.join(self.run_dir, self.demux_dir, "UnassignedSequences.csv")


### PR DESCRIPTION
Project names are added in the aggregated `IndexAssignment.csv`. The percentages of unknown indexes are corrected based on individual lane yield in the aggregated `UnassignedSequences.csv`. @ssjunnebo @alneberg